### PR TITLE
Simplify tiers UI to a single tier-count stepper

### DIFF
--- a/src/ranker/web/app.py
+++ b/src/ranker/web/app.py
@@ -71,6 +71,7 @@ def create_app(data_dir: Optional[str] = None) -> FastAPI:
         out = {
             "list": name,
             "scale": spec.scale,
+            "n_items": len(spec.items),
             "asked": len(ranker.model.comparisons),
             "progress": ranker.progress(),
             "should_stop": stop,

--- a/src/ranker/web/static/app.js
+++ b/src/ranker/web/static/app.js
@@ -4,6 +4,7 @@ const enc = encodeURIComponent;
 
 let LIST = null;
 let SCALE = 7;
+let KUSER = false; // has the user manually set the tier count?
 let CURRENT = null; // {left, right}
 let LAST = null; // last state payload (for resume)
 let SCREEN = "home";
@@ -142,7 +143,11 @@ function applyState(st) {
 
 async function openSession(name) {
   LIST = name;
-  applyState(await api("/session/" + enc(name)));
+  const st = await api("/session/" + enc(name));
+  // Default tier count to floor(sqrt(n)); user can adjust with the stepper.
+  KUSER = false;
+  $("#tier-k").value = Math.max(1, Math.floor(Math.sqrt(st.n_items || 4)));
+  applyState(st);
 }
 
 async function submit(answer) {
@@ -161,27 +166,9 @@ async function undo() {
 
 // -- result -------------------------------------------------------------------
 
-// [low, high, label] for the grouping slider: narrower band -> more tiers.
-const BANDS = [
-  [0.4, 0.6, "fine"],
-  [0.3, 0.7, "balanced"],
-  [0.2, 0.8, "coarse"],
-  [0.1, 0.9, "broad"],
-];
-
 function tierParams() {
-  const method = $("#tier-method").value;
-  const k = parseInt($("#tier-k").value, 10) || 5;
-  const [low, high] = BANDS[parseInt($("#tier-band").value, 10)];
-  const q = new URLSearchParams({ method, k, low, high });
-  return q.toString();
-}
-
-function syncTierControls() {
-  const method = $("#tier-method").value;
-  $("#k-wrap").classList.toggle("hidden", method !== "kmeans");
-  $("#band-wrap").classList.toggle("hidden", method !== "graph");
-  $("#band-label").textContent = BANDS[parseInt($("#tier-band").value, 10)][2];
+  const k = parseInt($("#tier-k").value, 10) || 1;
+  return new URLSearchParams({ method: "kmeans", k }).toString();
 }
 
 function renderResult(data, doExport) {
@@ -217,7 +204,6 @@ function renderResult(data, doExport) {
 }
 
 async function showResult(doExport) {
-  syncTierControls();
   const q = tierParams();
   const data = doExport
     ? (await post("/session/" + enc(LIST) + "/finish?" + q)).result
@@ -243,8 +229,9 @@ $("#finish").onclick = () => showResult(true);
 $("#resume").onclick = () => (LAST && LAST.pair ? renderCompare(LAST) : openSession(LIST));
 $("#home-from-compare").onclick = loadHome;
 $("#home-from-result").onclick = loadHome;
-$("#tier-method").onchange = () => showResult(false);
-$("#tier-k").oninput = () => showResult(false);
-$("#tier-band").oninput = () => showResult(false);
+$("#tier-k").oninput = () => {
+  KUSER = true;
+  showResult(false);
+};
 
 loadHome();

--- a/src/ranker/web/static/index.html
+++ b/src/ranker/web/static/index.html
@@ -67,18 +67,8 @@ Akira | akira.jpg | cyberpunk"></textarea>
       <h2 id="result-title">Ranking</h2>
 
       <div class="controls">
-        <label>Tiers by
-          <select id="tier-method">
-            <option value="graph">confidence (auto count)</option>
-            <option value="kmeans">fixed count</option>
-          </select>
-        </label>
-        <label id="k-wrap" class="hidden">how many
-          <input id="tier-k" type="number" min="1" max="20" value="5" />
-        </label>
-        <label id="band-wrap">grouping
-          <input id="tier-band" type="range" min="0" max="3" step="1" value="1" />
-          <span id="band-label" class="hint">balanced</span>
+        <label>Number of tiers
+          <input id="tier-k" type="number" min="1" max="50" value="5" />
         </label>
       </div>
 


### PR DESCRIPTION
The dual graph/k-means picker plus grouping slider was fiddly. Replaces it with a single **number stepper** for the tier count.

- Tiers use **k-means** by default.
- Count defaults to **floor(√n)** (e.g. 3 tiers for 10 items) and is adjustable with the box + arrows.
- Recomputes live; the rest of the result screen (items ordered with scores, intransitivity note) is unchanged.
- Session state now returns `n_items` so the client can compute the default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)