### PR TITLE
Add CLI, console entry points, and rewrite README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,8 +20,13 @@ uv run pytest tests/test_bt.py
 uv run pytest tests/test_bt.py::test_bt_recovers_clear_order
 uv run pytest -k tiers
 
+# CLI (entry point `ranker`, or `python -m ranker`)
+uv run ranker new L --items "A,B,C" --scale 7
+uv run ranker rank L          # interactive; decimal answers allowed
+uv run ranker show L
+
 # Launch the web app (http://127.0.0.1:8000)
-uv run python -m ranker.web --port 8000 --data ranker-data
+uv run ranker-web --port 8000 --data ranker-data   # or: uv run ranker web
 ```
 
 Dependencies: runtime `numpy`, `scikit-learn`; `[project.optional-dependencies].web`
@@ -90,11 +95,17 @@ tagged `engine:"glicko"`.
 overridable via `$RANKER_DATA` or `--data`): `lists/` (Item/ListSpec input sets),
 `sessions/` (BT state), `rankings/` (exported md+json), `images/`. `ranker.web` is a
 FastAPI app (`create_app`) plus a static SPA in `web/static/`; launch with
-`uv run python -m ranker.web`. The web UI is integer-only (1..scale buttons/hotkeys);
+`uv run ranker-web`. The web UI is integer-only (1..scale buttons/hotkeys);
 decimals stay a CLI feature. The `Selector` is side-effect-free so the UI can poll
 `next_pair` each request.
 
+### CLI
+
+`ranker.cli` provides subcommands (`lists`, `new`, `rank`, `show`, `web`) over the same
+`Library` + `Ranker`. `run_session` is the interactive loop (decimal answers; `u`/`f`/`q`);
+its `read`/`write`/`save` callbacks are injectable for testing. Entry points in pyproject:
+`ranker` → `ranker.cli:main` (also `python -m ranker`), `ranker-web` → the web launcher.
+
 ### Not yet built
 
-CLI (interactive, decimal answers) and tiermaker.com export are designed
-(`docs/design.md` §11) but unimplemented. `main.py` is still a 2-line stub.
+tiermaker.com export is designed (`docs/design.md` §11) but unimplemented.

--- a/README.md
+++ b/README.md
@@ -1,35 +1,85 @@
 # Ranker
 
-Efficient library for ranking many items from sparse, adaptive pairwise comparisons.
+Rank many items from sparse, noisy **pairwise comparisons** — books to read, anime to
+watch, favorite characters — without doing all O(n²) matchups.
 
-## Motivation
+Comparing two things ("which do you prefer, A or B?") is easy and low-bias; ranking a
+whole list directly is hard. Ranker asks a small number of well-chosen pairwise questions
+and infers the full ranking, with uncertainty, from your answers.
 
-Building a ranked list from a large set of options (e.g., movies, characters, restaurants) can be difficult and tedious.  
-Pairwise comparison—asking “Which do you prefer: A or B?”—is often much easier and less prone to bias.  
-But doing all possible comparisons scales as O(n²), which is impractical for many items.
+## How it works
 
-**Ranker** addresses this by:
-- Using Glicko-style rating updates to infer item strength from limited, noisy data
-- Selecting the next pair of items to compare based on which comparison will be most informative (maximizing rating uncertainty reduction)
-- Rapidly converging to a useful ranking with far fewer than all possible pairwise comparisons
+- **Bayesian Bradley-Terry model.** Each item has a latent score; a single posterior over
+  all scores is refit after every answer. It assumes preferences are *mostly* transitive
+  but tolerates the occasional mistake and mild intransitivity.
+- **Graded answers.** You answer on a 1..*scale* scale (default 1–7, middle = tie), not
+  just A/B. The strength of preference roughly *doubles* the information per question.
+- **Active selection.** It asks the pair expected to be most informative next, and never
+  repeats an item from the previous question.
+- **Suggested budget.** Accuracy is good by ~3N comparisons (≈0.9 rank correlation in
+  simulation); the progress bar shows this as a recommendation — stop whenever you like.
+- **Tiers + diagnostics.** Output groups items into tiers and reports any cyclic
+  ("A > B > C > A") inconsistencies in your answers.
 
-## Features
+Design rationale: [`docs/design.md`](docs/design.md). Background research: [`research/`](research/).
 
-- Efficiently build rankings from sparse comparison data
-- Suggest the “next best” pair to compare
-- Robust to uncertainty and user error
-- Supports exporting/importing state and results
-- Groups items into “tiers” using clustering
+## Install
 
-## Installation
+The project is managed with [uv](https://docs.astral.sh/uv/):
 
 ```bash
-git clone https://github.com/maxjiang216/ranker.git
-cd ranker
-python3 -m venv .venv
-source .venv/bin/activate
-pip install -e .
-````
+uv sync --extra web      # installs the library + CLI + web app
+```
+
+## Command line
+
+```bash
+uv run ranker new Anime --items "Spirited Away,Akira,Cowboy Bebop,Naruto" --scale 7
+uv run ranker rank Anime      # interactive: answer 1..7 (decimals ok), u=undo f=finish q=quit
+uv run ranker show Anime      # print the current ranking + tiers
+uv run ranker lists
+```
+
+(Also available as `python -m ranker ...`.)
+
+## Web app
+
+```bash
+uv run ranker-web             # http://127.0.0.1:8000
+```
+
+Create lists (each item may have an image and description), compare with buttons or
+number keys, watch the progress bar, and finish to a tiered ranking. The web UI is
+integer-only; decimals are a CLI feature.
+
+Lists, in-progress sessions, and exported rankings are stored in a git-ignored
+`ranker-data/` folder (override with `--data DIR` or `$RANKER_DATA`).
+
+## Library API
+
+```python
+from ranker import Ranker
+
+r = Ranker.from_list(["A", "B", "C", "D"], scale=7)
+while not r.should_stop():
+    pair = r.next_pair()
+    if pair is None:
+        break
+    left, right = pair
+    r.record(left, right, answer=...)   # 1..scale, decimals allowed
+r.ranking()          # [(name, score, sd), ...] best first
+r.tiers(method="kmeans", k=3)
+r.report_cycles()    # intransitivity diagnostic
+```
+
+The original Glicko-based engine is preserved for posterity and selectable with
+`Ranker.from_list(..., engine="glicko")` (see `ranker.legacy`).
+
+## Development
+
+```bash
+uv run pytest
+```
 
 ## License
 

--- a/main.py
+++ b/main.py
@@ -1,3 +1,0 @@
-from ranker import Ranker
-
-r = Ranker.from_list(["A", "B"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,10 @@ dependencies = [
 ]
 requires-python = ">=3.8"
 
+[project.scripts]
+ranker = "ranker.cli:main"
+ranker-web = "ranker.web.__main__:main"
+
 [project.optional-dependencies]
 web = ["fastapi", "uvicorn"]
 

--- a/src/ranker/__main__.py
+++ b/src/ranker/__main__.py
@@ -1,0 +1,6 @@
+"""``python -m ranker`` runs the command-line interface."""
+
+from .cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/ranker/cli.py
+++ b/src/ranker/cli.py
@@ -1,0 +1,206 @@
+"""Command-line interface for the ranker.
+
+Subcommands::
+
+    ranker lists                       list saved lists
+    ranker new NAME --items a,b,c      create a list (or --file items.txt)
+    ranker rank NAME                   run an interactive comparison session
+    ranker show NAME                   print the current ranking + tiers
+    ranker web                         launch the localhost web app
+
+The interactive session accepts **decimal** answers on the 1..scale preference scale
+(1 = strongly left, scale = strongly right, middle = tie), plus ``u`` undo, ``f`` finish,
+``q`` quit. State is saved to the library after every answer.
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+from typing import Callable, List, Optional
+
+from .library import Item, Library, ListSpec
+from .session import Ranker
+
+
+def _default_tiers(n: int) -> int:
+    return max(1, int(math.isqrt(n)))
+
+
+def print_ranking(ranker: Ranker, *, k: Optional[int] = None, write: Callable = print) -> None:
+    ranking = ranker.ranking()
+    n = len(ranking)
+    if n == 0:
+        write("(no items)")
+        return
+    k = _default_tiers(n) if k is None else max(1, min(k, n))
+    scores = {name: s for name, s, _ in ranking}
+    tiers = ranker.tiers(method="kmeans", k=k)
+    for i, tier in enumerate(tiers, 1):
+        write(f"Tier {i}")
+        for name in tier:
+            write(f"  {name}  ({scores[name]:+.2f})")
+    rep = ranker.report_cycles()
+    ratio = rep["inconsistency_ratio"]
+    write(f"\nIntransitivity: {ratio:.0%} of preference strength is cyclic.")
+    if rep["cycles"]:
+        write("  loop: " + " > ".join(rep["cycles"][0]["items"]))
+
+
+def run_session(
+    ranker: Ranker,
+    *,
+    save: Callable[[Ranker], None],
+    read: Callable[[str], str] = input,
+    write: Callable = print,
+) -> None:
+    """Drive the interactive comparison loop. ``read`` is the prompt function (injectable
+    for testing); ``save`` persists the session after each answer."""
+    scale = ranker.model.scale
+    mid = (scale + 1) / 2
+    write(
+        f"Answer 1..{scale}  (1 = left, {scale:g} = right, {mid:g} = tie; decimals ok). "
+        "Commands: u=undo, f=finish, q=quit."
+    )
+    while True:
+        pair = ranker.next_pair()
+        if pair is None:
+            write("\nAll pairs compared.")
+            break
+        left, right = pair
+        prog = ranker.progress()
+        bar = f"[{prog['questions_asked']}/~{prog['target']} suggested, {prog['confidence']:.0%} confident]"
+        try:
+            raw = read(f"\n{bar}\n  1·{left}   vs   {right}·{scale}\n> ").strip()
+        except EOFError:
+            raw = "q"
+
+        low = raw.lower()
+        if low in ("q", "quit"):
+            write("Saved. Bye.")
+            return
+        if low in ("f", "finish", "done"):
+            break
+        if low in ("u", "undo"):
+            undone = ranker.undo()
+            write(f"  undid {undone}" if undone else "  nothing to undo")
+            save(ranker)
+            continue
+        try:
+            answer = float(raw)
+        except ValueError:
+            write(f"  ? enter a number 1..{scale}, or u/f/q")
+            continue
+        if not (1.0 <= answer <= scale):
+            write(f"  ? out of range (1..{scale})")
+            continue
+        ranker.record(left, right, answer)
+        save(ranker)
+
+    write("")
+    print_ranking(ranker, write=write)
+
+
+# -- subcommands --------------------------------------------------------------
+
+
+def cmd_lists(lib: Library, args) -> int:
+    names = lib.list_names()
+    if not names:
+        print("No lists yet. Create one with: ranker new NAME --items a,b,c")
+        return 0
+    for name in names:
+        spec = lib.load_list(name)
+        flag = " (in progress)" if lib.has_session(name) else ""
+        print(f"{name}  [{len(spec.items)} items, scale {spec.scale}]{flag}")
+    return 0
+
+
+def cmd_new(lib: Library, args) -> int:
+    if args.file:
+        with open(args.file) as f:
+            names = [line.strip() for line in f if line.strip()]
+    else:
+        names = [s.strip() for s in (args.items or "").split(",") if s.strip()]
+    if len(names) < 2:
+        print("Need at least 2 items (--items a,b,c or --file path).")
+        return 1
+    if len(set(names)) != len(names):
+        print("Item names must be unique.")
+        return 1
+    spec = ListSpec(name=args.name, scale=args.scale, items=[Item(n) for n in names])
+    lib.save_list(spec)
+    print(f"Created '{args.name}' with {len(names)} items (scale {args.scale}).")
+    print(f"Start ranking with: ranker rank {args.name!r}")
+    return 0
+
+
+def cmd_rank(lib: Library, args) -> int:
+    if not lib.list_exists(args.name):
+        print(f"No such list: {args.name!r}. See 'ranker lists'.")
+        return 1
+    ranker = lib.get_session(args.name)
+    run_session(ranker, save=lambda r: lib.save_session(args.name, r))
+    lib.save_session(args.name, ranker)
+    paths = lib.export_ranking(args.name, ranker, tier_method="kmeans", k=_default_tiers(len(ranker.model.items)))
+    print(f"\nSaved ranking to {paths['md']}")
+    return 0
+
+
+def cmd_show(lib: Library, args) -> int:
+    if not lib.list_exists(args.name):
+        print(f"No such list: {args.name!r}. See 'ranker lists'.")
+        return 1
+    ranker = lib.get_session(args.name)
+    print_ranking(ranker, k=args.tiers)
+    return 0
+
+
+def cmd_web(lib: Library, args) -> int:
+    import uvicorn
+
+    from .web.app import create_app
+
+    uvicorn.run(create_app(args.data), host=args.host, port=args.port)
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="ranker", description="Rank items via pairwise comparisons.")
+    p.add_argument("--data", default=None, help="Library folder (default ./ranker-data or $RANKER_DATA)")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    sub.add_parser("lists", help="list saved lists").set_defaults(func=cmd_lists)
+
+    pn = sub.add_parser("new", help="create a list")
+    pn.add_argument("name")
+    pn.add_argument("--items", help="comma-separated item names")
+    pn.add_argument("--file", help="file with one item per line")
+    pn.add_argument("--scale", type=int, default=7)
+    pn.set_defaults(func=cmd_new)
+
+    pr = sub.add_parser("rank", help="run an interactive comparison session")
+    pr.add_argument("name")
+    pr.set_defaults(func=cmd_rank)
+
+    ps = sub.add_parser("show", help="print the current ranking + tiers")
+    ps.add_argument("name")
+    ps.add_argument("--tiers", type=int, default=None, help="number of tiers (default floor(sqrt(n)))")
+    ps.set_defaults(func=cmd_show)
+
+    pw = sub.add_parser("web", help="launch the localhost web app")
+    pw.add_argument("--host", default="127.0.0.1")
+    pw.add_argument("--port", type=int, default=8000)
+    pw.set_defaults(func=cmd_web)
+
+    return p
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = build_parser().parse_args(argv)
+    lib = Library(args.data)
+    return args.func(lib, args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,57 @@
+from ranker.cli import main, run_session
+from ranker.session import Ranker
+
+
+def test_new_and_lists(tmp_path, capsys):
+    data = str(tmp_path / "d")
+    assert main(["--data", data, "new", "Books", "--items", "A,B,C", "--scale", "5"]) == 0
+    assert main(["--data", data, "lists"]) == 0
+    out = capsys.readouterr().out
+    assert "Books" in out and "3 items" in out
+
+
+def test_new_rejects_too_few(tmp_path, capsys):
+    assert main(["--data", str(tmp_path), "new", "X", "--items", "A"]) == 1
+
+
+def test_new_from_file(tmp_path):
+    f = tmp_path / "items.txt"
+    f.write_text("A\nB\nC\nD\n")
+    assert main(["--data", str(tmp_path / "d"), "new", "L", "--file", str(f)]) == 0
+
+
+def test_show_unknown_list(tmp_path, capsys):
+    assert main(["--data", str(tmp_path), "show", "Nope"]) == 1
+
+
+def test_run_session_records_and_ranks():
+    r = Ranker.from_list(["A", "B", "C", "D"], seed=1)
+    answers = iter(["7", "7", "7", "7", "7", "f"])
+    out = []
+    saved = []
+    run_session(
+        r,
+        save=lambda x: saved.append(len(x.model.comparisons)),
+        read=lambda prompt: next(answers),
+        write=out.append,
+    )
+    assert len(r.model.comparisons) == 5
+    assert saved == [1, 2, 3, 4, 5]
+    assert any("Tier 1" in line for line in out)
+
+
+def test_run_session_undo_then_quit():
+    r = Ranker.from_list(["A", "B", "C", "D"], seed=1)
+    answers = iter(["7", "u", "q"])
+    out = []
+    run_session(r, save=lambda x: None, read=lambda prompt: next(answers), write=out.append)
+    assert len(r.model.comparisons) == 0  # recorded one, undid it, quit
+
+
+def test_run_session_rejects_out_of_range():
+    r = Ranker.from_list(["A", "B", "C"], seed=1)
+    answers = iter(["9", "abc", "4", "q"])  # bad, bad, ok, quit
+    out = []
+    run_session(r, save=lambda x: None, read=lambda prompt: next(answers), write=out.append)
+    assert len(r.model.comparisons) == 1
+    assert any("out of range" in line for line in out)


### PR DESCRIPTION
## Summary

Adds a command-line interface, proper console entry points, and a README that reflects the current design.

## CLI (`ranker.cli`)

Subcommands over the same `Library` + `Ranker`:

```bash
ranker new Anime --items "Spirited Away,Akira,Cowboy Bebop,Naruto" --scale 7
ranker rank Anime      # interactive: answer 1..7 (decimals ok), u=undo f=finish q=quit
ranker show Anime      # current ranking + tiers
ranker lists
ranker web             # launch the web app
```

The interactive `rank` loop is the one interface that supports **decimal** answers; it shows live progress against the 3N suggested budget, saves after every answer, and prints a tiered ranking (k-means, `floor(√n)` tiers) plus the intransitivity report on finish. `run_session`'s `read`/`write`/`save` callbacks are injectable, so the loop is unit-tested without real input.

## Entry points & `main.py`

Adds `[project.scripts]`: `ranker` → `ranker.cli:main` (also `python -m ranker`) and `ranker-web` → the web launcher. Deletes the obsolete root `main.py` stub — a `src/`-layout package exposes console entry points rather than a top-level script.

## README

Rewritten around the Bradley-Terry engine, graded answers, active selection, CLI, web app, library folder, and uv. Old Glicko-era copy removed.

## Tests

50 passing (7 new CLI tests: list creation/validation, file input, unknown-list handling, and the interactive loop incl. undo/quit and out-of-range rejection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)